### PR TITLE
Upgrade to SilverStripe 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,13 @@
         }
     ],
     "require": {
-        "dnadesign/silverstripe-elemental": "^5",
-        "silverstripe/linkfield": "^4.0",
-        "symbiote/silverstripe-gridfieldextensions": "^4"
+        "php": "^8.1",
+        "dnadesign/silverstripe-elemental": "^6",
+        "silverstripe/linkfield": "^5",
+        "symbiote/silverstripe-gridfieldextensions": "^5"
     },
     "require-dev": {
-        "silverstripe/recipe-testing": "^3",
+        "silverstripe/recipe-testing": "^4",
         "silverstripe/standards": "^1",
         "squizlabs/php_codesniffer": "^3"
     },
@@ -42,5 +43,10 @@
             "silverstripe/vendor-plugin": true
         },
         "process-timeout": 600
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "6.0.x-dev"
+        }
     }
 }


### PR DESCRIPTION
Upgrades the module to SilverStripe 6 compatibility.

## Changes

- Updated PHP requirement to ^8.1
- Updated all core dependencies to SS6-compatible versions:
  - `dnadesign/silverstripe-elemental`: ^5 → ^6
  - `silverstripe/linkfield`: ^4.0 → ^5
  - `symbiote/silverstripe-gridfieldextensions`: ^4 → ^5
  - `silverstripe/recipe-testing`: ^3 → ^4
- Added branch-alias pointing to dev-master
- No code changes required - all code is SS6 compatible

## Testing

- ✅ PHPCS: Clean (zero violations)
- ✅ Code review: No namespace changes or breaking changes needed

This prepares the module for the 6.0.0 release.