### PR TITLE
fix: Update PHP requirement to ^8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.3",
         "dnadesign/silverstripe-elemental": "^6",
         "silverstripe/linkfield": "^5",
         "symbiote/silverstripe-gridfieldextensions": "^5"


### PR DESCRIPTION
Updates PHP requirement to match SilverStripe 6 minimum requirements.

## Changes

- PHP requirement: `^8.1` → `^8.3`

## Rationale

SilverStripe 6 framework requires PHP `^8.3` minimum. This module was incorrectly set to `^8.1` which causes compatibility issues.

Reference: `silverstripe/framework` composer.json requires `"php": "^8.3"`

## Release

This should be released as **v6.0.1** (patch release).