### PR TITLE
REFACTOR: Remove getType() override to allow extensibility

### DIFF
--- a/src/Elements/LinksElement.php
+++ b/src/Elements/LinksElement.php
@@ -37,13 +37,13 @@ class LinksElement extends BaseElement
      * @var string
      * @config
      */
-    private static $singular_name = 'Links Element';
+    private static $singular_name = 'Links';
 
     /**
      * @var string
      * @config
      */
-    private static $plural_name = 'Links Elements';
+    private static $plural_name = 'Links Blocks';
 
     /**
      * @var bool
@@ -120,13 +120,5 @@ class LinksElement extends BaseElement
         $blockSchema = parent::provideBlockSchema();
         $blockSchema['content'] = $this->getSummary();
         return $blockSchema;
-    }
-
-    /**
-     * @return string
-     */
-    public function getType()
-    {
-        return _t(__CLASS__ . '.BlockType', 'Links');
     }
 }


### PR DESCRIPTION
## Summary

Remove the `getType()` method override so the element inherits `BaseElement::getType()` which uses `i18n_singular_name()`. This allows sites to customize the element's display name via extensions by setting `$singular_name`.

## Changes

- Removed the `getType()` method from `LinksElement`
- Updated `$singular_name` from `'Links Element'` to `'Links'`
- Updated `$plural_name` from `'Links Elements'` to `'Links Blocks'`

## Rationale

The base `BaseElement::getType()` implementation already uses `$this->i18n_singular_name()`:

```php
public function getType()
{
    $default = $this->i18n_singular_name() ?: 'Block';
    return _t(static::class . '.BlockType', $default);
}
```

By removing the override, extensions can now customize the display name in the CMS element picker by simply setting `$singular_name`, without needing to override the entire method.

Fixes #22

Related: dynamic/silverstripe-essentials-tools#68