### PR TITLE
Merge SS5 branch (5) into SS6 branch (6)

### DIFF
--- a/src/Elements/LinksElement.php
+++ b/src/Elements/LinksElement.php
@@ -37,13 +37,13 @@ class LinksElement extends BaseElement
      * @var string
      * @config
      */
-    private static $singular_name = 'Links Element';
+    private static $singular_name = 'Links';
 
     /**
      * @var string
      * @config
      */
-    private static $plural_name = 'Links Elements';
+    private static $plural_name = 'Links Blocks';
 
     /**
      * @var bool
@@ -120,13 +120,5 @@ class LinksElement extends BaseElement
         $blockSchema = parent::provideBlockSchema();
         $blockSchema['content'] = $this->getSummary();
         return $blockSchema;
-    }
-
-    /**
-     * @return string
-     */
-    public function getType()
-    {
-        return _t(__CLASS__ . '.BlockType', 'Links');
     }
 }


### PR DESCRIPTION
## Summary

Merge the SS5 branch into the SS6 branch to bring forward the `getType()` refactor changes.

## Changes from SS5 branch

- Removed `getType()` method override to allow extensibility via `$singular_name`
- Updated `$singular_name` and `$plural_name` values

## Related

- Original SS5 PR: #23
- Parent issue: dynamic/silverstripe-essentials-tools#68