### PR TITLE
chore(#26): remove stale branch-alias pointing at legacy master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,10 +43,5 @@
             "silverstripe/vendor-plugin": true
         },
         "process-timeout": 600
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "6.0.x-dev"
-        }
     }
 }


### PR DESCRIPTION
## Summary
- Removes \`extra.branch-alias\` (\`dev-master: 6.0.x-dev\`) — a leftover from the integer-branch migration. The \`6\` branch already resolves to \`6.x-dev\` on its own; the alias only made the stale legacy \`master\` branch a valid \`^6.0@dev\` candidate.

Closes #26

Found while auditing suite-wide composer.json VCS/alias plumbing (see essentials-ss6 audit, unrelated to the dnadesign/silverstripe-embed 2.0.0 release that prompted the check).

## Test plan
- [x] Resulting composer.json is valid JSON
- [ ] \`composer show dynamic/silverstripe-elemental-links\` in a consumer still resolves to \`6.x-dev\`, not \`6.0.x-dev\`/legacy \`master\`